### PR TITLE
Better errors for Ultraviolet-Node

### DIFF
--- a/public/error.html
+++ b/public/error.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, shrink-to-fit=no"
+    />
+    <title>Ultraviolet | Error</title>
+    <meta
+      name="description"
+      content="Ultraviolet is a highly sophisticated proxy used for evading internet censorship or accessing websites in a controlled sandbox using the power of service-workers. Unblock sites today!"
+    />
+    <meta
+      name="theme-color"
+      media="(prefers-color-scheme: dark)"
+      content="#434c5e"
+    />
+    <meta name="googlebot" content="noindex, nofollow, nosnippet" />
+    <base href="/">
+    <link rel="shortcut icon" content="favicon.ico" />
+    <link rel="stylesheet" href="index.css" />
+  </head>
+
+  <body>
+    <div class="logo-wrapper left-margin">
+      <h1>
+        Ultraviolet | Error
+      </h1>
+    </div>
+    <div class="desc left-margin">
+      <p>
+        The server could not route your request.
+      </p>
+      <p class="error"></p>
+      <input type="button" class="register-sw" value="Register service worker">
+    </div>
+
+    <footer>
+      <a
+        title="For privacy implications related to Ultraviolet."
+        href="https://github.com/titaniumnetwork-development/Ultraviolet/raw/main/LICENSE"
+        style="margin-left: auto"
+        >License</a
+      >
+      <span>Ultraviolet &copy; TN 2022</span>
+    </footer>
+    <script src="uv/uv.bundle.js"></script>
+    <script src="uv/uv.config.js"></script>
+    <script src="error.js"></script>
+  </body>
+</html>

--- a/public/error.js
+++ b/public/error.js
@@ -1,0 +1,39 @@
+const errorContainer = document.querySelector(".error");
+const registerButton = document.querySelector(".register-sw");
+let registrarOpen = false;
+
+if (window.location.pathname.startsWith(__uv$config.prefix)) {
+  errorContainer.textContent += "The service worker is not registered. Click the button below to register the service worker.";
+  registerButton.style.display = "block";
+}
+
+function registrarResponse(response) {
+  if (response == "success") {
+    registerButton.style.display = "none";
+    let span = document.createElement("span");
+    span.className = "error-green";
+    span.textContent = "\n\nSuccess. Reloading now...";
+    errorContainer.appendChild(span);
+    window.location.reload();
+  }
+  if (response == "failure")
+    errorContainer.textContent += "\n\nFailed to register service worker.";
+}
+
+registerButton.onclick = () => {
+  if (!registrarOpen) {
+    registrarOpen = true;
+    let registrarFrame = document.createElement("iframe");
+    registrarFrame.style.display = "none";
+    registrarFrame.src = "./register-sw.html";
+    document.body.appendChild(registrarFrame);
+    function messageHandler(event) {
+      window.removeEventListener("message", messageHandler);
+      registrarFrame.removeAttribute("src");
+      document.body.removeChild(registrarFrame);
+      registrarOpen = false;
+      registrarResponse(event.data);
+    }
+    window.addEventListener("message", messageHandler);
+  }
+}

--- a/public/index.css
+++ b/public/index.css
@@ -28,12 +28,44 @@ body {
   color: white;
 }
 
-.logo-wrapper {
+.flex-center {
   display: flex;
-  align-items: center;
   justify-content: center;
+}
+
+.header-center {
+  align-items: center;
   flex-direction: column;
   margin-top: 10%;
+}
+
+.left-margin {
+  margin: 0px 16px;
+}
+
+.error {
+  color: #ff6666 !important;
+  white-space: pre-wrap;
+}
+
+.error-green {
+  color: #66ff66 !important;
+}
+
+.register-sw {
+  color: white;
+  background: #555555;
+  cursor: pointer;
+  outline: none;
+  border: none;
+  border-radius: 6px;
+  padding: 16px 20px;
+  line-height: 16px;
+  display: none;
+}
+
+.register-sw:active {
+  background: #333333;
 }
 
 .logo {
@@ -74,16 +106,6 @@ footer a {
 
 footer a:hover {
   text-decoration: underline;
-}
-
-form {
-  display: flex;
-  justify-content: center;
-}
-
-.desc {
-  display: flex;
-  justify-content: center;
 }
 
 .desc p {

--- a/public/index.html
+++ b/public/index.html
@@ -59,7 +59,7 @@
   </head>
 
   <body>
-    <div title="Ultraviolet Logo" class="logo-wrapper">
+    <div title="Ultraviolet Logo" class="flex-center logo-wrapper header-center">
       <img class="logo" src="uv.png" alt="Ultraviolet" />
       <h1
         title="Ultraviolet supports YouTube, GeForce NOW and more! Service by TitaniumNetwork."
@@ -69,7 +69,7 @@
     </div>
     <div
       title="Ultraviolet uses the power of service-workers and more! Unblock many sites today with Ultraviolet!"
-      class="desc"
+      class="flex-center desc"
     >
       <p>
         Ultraviolet is highly sophisticated proxy used for evading internet
@@ -77,7 +77,7 @@
       </p>
     </div>
 
-    <form>
+    <form class="flex-center">
       <input placeholder="Search the web freely" />
     </form>
     <footer>

--- a/public/register-sw.html
+++ b/public/register-sw.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Registering Service Worker...</title>
+  </head>
+
+  <body>
+    <h1>Registering Service Worker...</h1>
+    <p id="state"></p>
+    <script src="uv/uv.bundle.js"></script>
+    <script src="uv/uv.config.js"></script>
+    <script src="register-sw.js"></script>
+  </body>
+</html>

--- a/public/register-sw.js
+++ b/public/register-sw.js
@@ -1,0 +1,22 @@
+const stateContainer = document.getElementById("state");
+
+function finish(state) {
+  stateContainer.textContent = state;
+  console.log("Registering ultraviolet service worker... " + state);
+  window.parent.postMessage(state, "*");
+}
+
+try {
+  window.navigator.serviceWorker
+    .register("./sw.js", {
+      scope: __uv$config.prefix,
+    })
+    .then(() => {
+      finish("success");
+    })
+    .catch(() => {
+      finish("failure");
+    });
+} catch (e) {
+  finish("failure");
+}


### PR DESCRIPTION
No more Cannot GET errors. This PR also includes `register-sw.html`, which can be iframed to preemptively register the service worker (intended to be used cross-domain).

I'll make another PR in [Ultraviolet-Node](https://github.com/titaniumnetwork-development/Ultraviolet-Node) to update the server. @e9x, please bump the version.

Screenshots:
<details>
<summary>Show</summary>

![Error](https://cdn.discordapp.com/attachments/926566427664715857/1037159500278399017/unknown.png)
![Error on ultraviolet path](https://cdn.discordapp.com/attachments/926566427664715857/1037159501146624030/unknown.png)

</details>